### PR TITLE
Add body-scroll-lock package that helps fix bug with scroll body

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
     "autoprefixer": "^9.5.0",
+    "body-scroll-lock": "^2.6.1",
     "browser-lang": "0.0.1",
     "formik": "^1.5.1",
     "gatsby": "^2.3.30",
@@ -18,7 +19,7 @@
     "gatsby-plugin-sharp": "^2.0.35",
     "gatsby-source-filesystem": "^2.0.21",
     "gatsby-transformer-sharp": "^2.1.13",
-    "node-sass": "^4.11.0",
+    "node-sass": "^4.12.0",
     "prop-types": "^15.6.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
@@ -49,6 +50,8 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "devDependencies": {
+    "eslint": "^5.16.0",
+    "eslint-config-google": "^0.12.0",
     "gatsby-transformer-json": "^2.1.8"
   }
 }

--- a/src/components/nav-mobile.js
+++ b/src/components/nav-mobile.js
@@ -1,20 +1,31 @@
 import React, { Component } from 'react'
 import Nav from './nav'
 import Lang from './language'
+import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 
 
 class NavMobile extends Component {
-   state = { isToggle: false }
+  state = { isToggle: false }
+  targetElement = null
+
+  componentDidMount() {
+    this.targetElement = document.querySelector('.nav-mobile__menu')
+  }
+
+  bodyScrollLockToggle = () => {
+    this.state.isToggle ? enableBodyScroll(this.targetElement) : disableBodyScroll(this.targetElement)
+  }
 
   toggleMenu = () => {
-    document.body.classList.toggle('hidden')
     this.setState((state) => { return {isToggle: !state.isToggle} })
+    this.bodyScrollLockToggle()
   }
+
   render() {
     return (
       <div className='nav-mobile'>
         <button onClick={this.toggleMenu} className={`nav-mobile__btn  ${this.state.isToggle ? 'nav-mobile__btn--close' : ''}`}></button>
-        <div className={`nav-mobile__menu ${this.state.isToggle ?  'nav-mobile__menu--open' : '' }`}><Nav mobile /></div>  
+        <div className={`nav-mobile__menu ${this.state.isToggle ? 'nav-mobile__menu--open' : ''}`}><Nav mobile /></div>  
       </div>
     )
   }


### PR DESCRIPTION
When add block with position fixed and overlap all body and style for body overflow hidden, body scrolling anyway still working in safari on mobile devices. this package helps fix bug